### PR TITLE
Bug/android api 14

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -15,7 +15,7 @@ set(xCONFIG
 )
 
 ExternalProject_Add(	lzo
-	URL					http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz
+	URL					https://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz
 	URL_HASH			SHA1=4924676a9bae5db58ef129dc1cebce3baa3c4b5d
 	CONFIGURE_COMMAND	<SOURCE_DIR>/configure ${xCONFIG} --disable-shared
 	BUILD_COMMAND		make -j8

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -26,7 +26,7 @@ ExternalProject_Add(	lzo
 ExternalProject_Add(	libressl
 	URL					https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.6.2.tar.gz
 	URL_HASH			SHA256=b029d2492b72a9ba5b5fcd9f3d602c9fd0baa087912f2aaecc28f52f567ec478
-	CONFIGURE_COMMAND	<SOURCE_DIR>/configure ${xCONFIG} --disable-shared
+	CONFIGURE_COMMAND	<SOURCE_DIR>/configure ${xCONFIG} --disable-shared ac_cv_func_getpagesize=yes
 	BUILD_COMMAND		make -j8 -C crypto
 	INSTALL_COMMAND		make -C crypto install DESTDIR=${CMAKE_CURRENT_BINARY_DIR} &&
 						make -C include install DESTDIR=${CMAKE_CURRENT_BINARY_DIR} &&

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -24,8 +24,8 @@ ExternalProject_Add(	lzo
 )
 
 ExternalProject_Add(	libressl
-	URL					https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.5.5.tar.gz
-	URL_HASH			SHA256=e57f5e3d5842a81fe9351b6e817fcaf0a749ca4ef35a91465edba9e071dce7c4
+	URL					https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.6.2.tar.gz
+	URL_HASH			SHA256=b029d2492b72a9ba5b5fcd9f3d602c9fd0baa087912f2aaecc28f52f567ec478
 	CONFIGURE_COMMAND	<SOURCE_DIR>/configure ${xCONFIG} --disable-shared
 	BUILD_COMMAND		make -j8 -C crypto
 	INSTALL_COMMAND		make -C crypto install DESTDIR=${CMAKE_CURRENT_BINARY_DIR} &&

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
 	defaultConfig {
 		applicationId "org.pacien.tincapp"
-		minSdkVersion 21
+		minSdkVersion 14
 		targetSdkVersion 21
         multiDexEnabled true
 		versionCode 7


### PR DESCRIPTION
This should fix issue #23 for now.
Since I only have Android 6+ devices I wasn't able to test the app on Android 4. However I can build everything with a minSdkVersion of 14 and the app is still working without problems on my Android 6 device.

Detailed Info:
I had to add a configure-flag ("ac_cv_func_getpagesize=yes") when building libressl, because the libressl configuration system didn't detect the getpagesize function (which is defined in unistd.h on android) by itself when the minimum android api-level was lower than 21.

There is already an issue at libressl (libressl-portable/portable#354) which is adressing the problem, the additional configure flag probably can be removed again as soon as there is an official fix in an upcoming libressl release.